### PR TITLE
зміна типу параметра на IReadOnlyList для уникнення копіювання

### DIFF
--- a/ClassLibrary1/ConsoleRenderer.cs
+++ b/ClassLibrary1/ConsoleRenderer.cs
@@ -67,7 +67,7 @@ namespace ClassLibrary1
 
         private void SetConsoleColors(LetterState s)
         {
-            if (s == LetterState.CorectLetter)
+            if (s == LetterState.CorrectLetter)
             {
                 Console.BackgroundColor = ConsoleColor.DarkGreen;
                 Console.ForegroundColor = ConsoleColor.White;

--- a/ClassLibrary1/Guess.cs
+++ b/ClassLibrary1/Guess.cs
@@ -9,9 +9,9 @@ namespace ClassLibrary1
     public class Guess
     {
         public string Word;
-        public List<LetterState> States;
+        public IReadOnlyList<LetterState> States;
 
-        public Guess(string word, List<LetterState> states)
+        public Guess(string word, IReadOnlyList<LetterState> states)
         {
             Word = word.ToUpperInvariant();
             States = states;

--- a/ClassLibrary1/Word.cs
+++ b/ClassLibrary1/Word.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 public class Word
 {
-    public HashSet<string> AllWords { get; private set; } = new();
+    public IReadOnlyList<string> AllWords { get; private set; }
     public string TargetWord { get; private set; }
 
     private Random random = new();
@@ -27,7 +27,7 @@ public class Word
                                       .Trim()
                                       .ToUpperInvariant());
 
-        AllWords = new HashSet<string>(lines);
+        AllWords = new List<string>(lines).AsReadOnly();
     }
 
     public string GenerateTargetWord()

--- a/ClassLibrary1/WordChecker.cs
+++ b/ClassLibrary1/WordChecker.cs
@@ -4,7 +4,7 @@ namespace ClassLibrary1
 {
     public class WordChecker
     {
-        public List<LetterState> CheckGuess(string guess, string target)
+        public IReadOnlyList<LetterState> CheckGuess(string guess, string target)
         {
             guess = guess.ToUpperInvariant();
             target = target.ToUpperInvariant();
@@ -35,7 +35,7 @@ namespace ClassLibrary1
                 }
             }
 
-            return result;
+            return result.AsReadOnly();
         }
     }
 }


### PR DESCRIPTION
Closes #1 . Під час роботи над різними гілками паралельно помітив, що в ConsoleRenderer залишилася стара назва CorectLetter. Виправив одразу тут, щоб уникнути конфліктів при мержі.
